### PR TITLE
Add a setuid utility to use realtime scheduling

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -53,6 +53,11 @@ RUN wget http://sdp-services.kat.ac.za/mirror/github.com/krallin/tini/releases/d
     chmod +x /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
+# Create a setuid binary to assist with realtime scheduling
+COPY schedrr.c /usr/local/src
+RUN gcc -o /usr/local/bin/schedrr /usr/local/src/schedrr.c -Wall -Wextra -s -O2 && \
+    chmod u+s /usr/local/bin/schedrr
+
 # Create and switch to a user which will be used to run commands with reduced
 # privileges.
 RUN adduser --disabled-password --gecos 'unprivileged user' kat

--- a/docker-base/schedrr.c
+++ b/docker-base/schedrr.c
@@ -1,0 +1,40 @@
+/* Set a real-time scheduling policy, then drop privileges and exec a program.
+ * This is intended to be a setuid binary. To minimise the attack surface, it
+ * does not take any command-line arguments, and is hard-coded to set the
+ * policy to SCHED_RR with priority 1.
+ */
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <sched.h>
+
+int main(int argc, char * const *argv)
+{
+    int result;
+    struct sched_param param = {};
+
+    if (argc < 2)
+    {
+        fputs("Usage: schedrr program [args]\n", stderr);
+        return 2;
+    }
+    param.sched_priority = 1;
+    result = sched_setscheduler(0, SCHED_RR, &param);
+    if (result != 0)
+    {
+        perror("sched_setscheduler failed");
+        return 1;
+    }
+    /* Drop privileges */
+    result = seteuid(getuid());
+    if (result != 0)
+    {
+        perror("seteuid failed");
+        return 1;
+    }
+    execvp(argv[1], argv + 1);
+    /* If execvp returns, it definitely failed */
+    perror("execvp failed");
+    return 1;
+}


### PR DESCRIPTION
This is only effective when --cap-add SYS_NICE is passed to Docker to
give root the capability. This makes real-time scheduling available to
the kat user inside the container when it has been enabled with
--cap-add.