### PR TITLE
Python 3 support in katsdpdockerbase

### DIFF
--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -y update && apt-get -y install \
     apt-transport-https \
     build-essential pkg-config git-core software-properties-common wget curl \
     python python-dev libffi-dev libssl-dev python-pip python-virtualenv \
+    python3 python3-dev python3-pip python3-virtualenv \
     libboost-program-options-dev \
     libboost-python-dev \
     libboost-system-dev \
@@ -83,14 +84,26 @@ RUN virtualenv ~/tmp-ve && \
     ~/bin/install-requirements.py -r ~/docker-base/pre-requirements.txt && \
     ~/bin/install-requirements.py -r ~/docker-base/base-requirements.txt && \
     rm -r ~/tmp-ve
+# Same against for Python 3
+RUN virtualenv -p /usr/bin/python3 ~/tmp-ve3 && \
+    . ~/tmp-ve3/bin/activate && \
+    ~/bin/install-requirements.py -r ~/docker-base/pre-requirements.txt && \
+    ~/bin/install-requirements.py -r ~/docker-base/base-requirements.txt && \
+    rm -r ~/tmp-ve3
 
-# Create a virtual environment for use in child images
+# Create virtual environments for use in child images
 RUN virtualenv ~/ve && \
     . ~/ve/bin/activate && \
     ~/bin/install-requirements.py -r ~/docker-base/pre-requirements.txt && \
     ~/bin/install-requirements.py -d ~/docker-base/base-requirements.txt manhole
-# Activate it. We can't use ~/ve/bin/activate, because any environment set in a
-# RUN step is lost at the end of the step. We also add ~/bin to PATH so that
-# install-requirements.py can be found.
-ENV PATH="/home/kat/ve/bin:/home/kat/bin:$PATH" \
-    VIRTUAL_ENV="/home/kat/ve"
+RUN virtualenv -p /usr/bin/python3 ~/ve3 && \
+    . ~/ve3/bin/activate && \
+    ~/bin/install-requirements.py -r ~/docker-base/pre-requirements.txt && \
+    ~/bin/install-requirements.py -d ~/docker-base/base-requirements.txt manhole
+# Activate the Python 2 environment. We can't use ~/ve/bin/activate, because
+# any environment set in a RUN step is lost at the end of the step. We also add
+# ~/bin to PATH so that install-requirements.py can be found.
+ENV PATH_PYTHON3="/home/kat/ve3/bin:/home/kat/bin:$PATH" \
+    PATH="/home/kat/ve/bin:/home/kat/bin:$PATH" \
+    VIRTUAL_ENV="/home/kat/ve" \
+    VIRTUAL_ENV_PYTHON3="/home/kat/v3"

--- a/docker-base/base-requirements.txt
+++ b/docker-base/base-requirements.txt
@@ -1,6 +1,7 @@
 alabaster==0.7.6
 ansicolors==1.0.2
 appdirs==1.4.0
+argparse==1.4.0
 Babel==2.1.1
 backports-abc==0.4
 backports.ssl-match-hostname==3.5.0.1
@@ -11,7 +12,7 @@ coverage==4.3.4
 Cython==0.23.4
 decorator==4.0.4
 docutils==0.12
-enum34==1.0.4
+enum34==1.1.6
 fakeredis==0.8.2
 funcsigs==0.4
 futures==3.0.3
@@ -19,7 +20,7 @@ h5py==2.5.0
 hiredis==0.2.0
 iniparse==0.4
 Jinja2==2.8
-katcp==0.6.1
+katcp==0.6.1; python_version<'3'
 katversion==0.6.0
 linecache2==1.0.0
 llvmlite==0.14.0
@@ -34,7 +35,7 @@ pandas==0.20.1
 pbr==1.8.1
 pkginfo==1.3.2
 ply==3.8
-ProxyTypes==0.9
+ProxyTypes==0.9; python_version<'3'
 pycparser==2.14
 pyephem==3.7.6.0
 Pygments==2.0.2

--- a/docker-base/install-requirements.py
+++ b/docker-base/install-requirements.py
@@ -12,7 +12,7 @@ pip that handles a few details:
   declare, and performs several phases of installation.
 """
 
-from __future__ import print_function, unicode_literals
+from __future__ import division, print_function, absolute_import, unicode_literals
 import sys
 import pkg_resources
 import re
@@ -118,7 +118,10 @@ def make_requirements(args):
                     if not args.allow_unversioned:
                         raise RuntimeError('{} is not version-pinned'.format(item.project_name))
             key = item.key
-            value = unicode(item)
+            if sys.version_info.major >= 3:
+                value = str(item)
+            else:
+                value = unicode(item)
         else:
             key = item
             value = item
@@ -148,7 +151,7 @@ def main():
 
     req = make_requirements(args)
     for epoch in req:
-        with tempfile.NamedTemporaryFile(suffix='.txt') as req_file:
+        with tempfile.NamedTemporaryFile('w', suffix='.txt') as req_file:
             for item in epoch:
                 print(item, file=req_file)
             req_file.flush()


### PR DESCRIPTION
Adds the Python C headers necessary for building Python 3 extensions, and creates a (non-default) Python 3 virtual environment. This is a first step towards having Jenkins run unit tests in Python 3 for those packages which can support it.