### PR TITLE
Add dask[array] requirements to base

### DIFF
--- a/docker-base/base-requirements.txt
+++ b/docker-base/base-requirements.txt
@@ -11,6 +11,7 @@ cffi==1.10.0
 coverage==4.4.1
 cycler==0.10.0
 Cython==0.23.4
+dask==0.17.4
 decorator==4.2.1
 docutils==0.12
 enum34==1.1.6
@@ -60,6 +61,7 @@ spead2==1.7.0
 sphinx-rtd-theme==0.1.9
 Sphinx==1.3.1
 subprocess32==3.2.7; python_version<'3'
+toolz==0.9.0
 tornado==4.5.3
 traceback2==1.4.0
 trollius==2.1


### PR DESCRIPTION
Since katdal now requires dask[array], it will pop up in many packages.