### PR TITLE
Upgrade to latest version of requests

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -65,7 +65,7 @@ python-lzf==0.2.4
 pytz==2015.7
 rdbtools==0.1.12
 redis==2.10.6
-requests==2.8.1
+requests==2.19.1
 scipy==0.19.1
 singledispatch==3.4.0.3
 six==1.10.0
@@ -80,5 +80,6 @@ tornado==4.5.3
 traceback2==1.4.0
 trollius==2.1
 unittest2==1.1.0
+urllib3==1.23
 # Note: yarl 1.2+ requires Python 3.5.3+
 yarl==1.1.1; python_version>='3'


### PR DESCRIPTION
The katdal unit tests were showing up bizarre connection failure issues
that go away when requests is upgraded. The upgrade also allows sessions
and responses to be directly used as context managers.