### PR TITLE
Add a utility script to run a program then clean up

### DIFF
--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -65,6 +65,8 @@ ENTRYPOINT ["/sbin/tini", "--"]
 # Create a setuid binary to assist with realtime scheduling
 COPY --from=build-schedrr /usr/local/bin/schedrr /usr/local/bin/schedrr
 RUN chmod u+s /usr/local/bin/schedrr
+# A helper script to run a program then clean up its scratch space
+COPY run-and-cleanup /usr/local/bin/run-and-cleanup
 
 # Create and switch to a user which will be used to run commands with reduced
 # privileges.

--- a/docker-base-runtime/run-and-cleanup
+++ b/docker-base-runtime/run-and-cleanup
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import argparse
+import signal
+import subprocess
+import sys
+import atexit
+import pathlib
+
+
+SIGNALS = [signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT,
+           signal.SIGUSR1, signal.SIGUSR2]
+
+
+def cleanup(path):
+    subprocess.call(['/bin/rm', '-rf', '--', path])
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run a command and delete a path when it terminates. '
+                    'Signals are forwarded to the executed process.',
+        usage='%(prog)s path -- command [args...]')
+    parser.add_argument('path', help='Path to clean up')
+    parser.add_argument('command', nargs='+', help='Command to run')
+    args = parser.parse_args()
+    atexit.register(cleanup, args.path)
+
+    try:
+        sub = subprocess.Popen(sys.argv[2:])
+    except OSError as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(127)
+
+    def handler(sig, frame):
+        sub.send_signal(sig)
+
+    for sig in SIGNALS:
+        signal.signal(sig, handler)
+    retcode = sub.wait()
+    if retcode < 0:
+        # Child was killed by signal -retcode
+        sys.exit(128 - retcode)
+    else:
+        sys.exit(retcode)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is intended to be used with the continuum imager, to ensure that
its temporary space gets cleaned up even if the container crashes or is
killed.