### PR TITLE
Add botocore to the base requirements

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -12,6 +12,7 @@ Babel==2.1.1
 backports-abc==0.4
 backports.ssl-match-hostname==3.5.0.1
 blinker==1.4
+botocore==1.10.77
 certifi==2018.1.18
 cffi==1.10.0
 chardet==3.0.4
@@ -36,6 +37,7 @@ idna==2.7
 idna-ssl==1.1.0
 ipaddress==1.0.18
 Jinja2==2.8
+jmespath==0.9.3
 katcp==0.6.2; python_version<'3'
 katversion==0.8
 linecache2==1.0.0


### PR DESCRIPTION
It's an optional dependency of katdal, so likely to get used in a few
places.