### PR TITLE
Fix run-and-cleanup script

### DIFF
--- a/docker-base-runtime/run-and-cleanup
+++ b/docker-base-runtime/run-and-cleanup
@@ -26,7 +26,7 @@ def main():
     atexit.register(cleanup, args.path)
 
     try:
-        sub = subprocess.Popen(sys.argv[2:])
+        sub = subprocess.Popen(args.command)
     except OSError as exc:
         print(exc, file=sys.stderr)
         sys.exit(127)


### PR DESCRIPTION
It was assuming the command started at position 2, but typical usage is
run-and-cleanup <path> -- <command> <args> and position 2 is the --.