### PR TITLE
Make mirror selectable

### DIFF
--- a/docker-base-build/Dockerfile
+++ b/docker-base-build/Dockerfile
@@ -14,13 +14,15 @@ RUN apt-get -y update && apt-get --no-install-recommends -y install \
     autoconf automake \
     casacore-dev libcfitsio-dev wcslib-dev
 
+ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
+
 # Install dev libraries from MLNX OFED
 RUN cd /tmp && \
     MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu18.04-x86_64 && \
-    wget --progress=dot:mega http://sdp-services.kat.ac.za/mirror/www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
+    mirror_wget --progress=dot:mega https://www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
     tar -zxf $MLNX_OFED_PATH.tgz && \
     echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \
-    wget -qO - http://sdp-services.kat.ac.za/mirror/www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mirror_wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         libibverbs-dev librdmacm-dev libvma-dev && \

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -7,8 +7,10 @@ USER root
 RUN apt-get -y update && apt-get install --no-install-recommends -y \
         opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev
 
+ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
+
 RUN CUDA_RUN_FILE=cuda_10.0.130_410.48_linux && \
-    wget --progress=dot:mega "http://sdp-services.kat.ac.za/mirror/developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/$CUDA_RUN_FILE" && \
+    mirror_wget --progress=dot:mega "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/$CUDA_RUN_FILE" && \
     sh ./$CUDA_RUN_FILE --silent --toolkit && \
     rm -- $CUDA_RUN_FILE /tmp/cuda* && \
     rm -r /usr/local/cuda/doc && \

--- a/docker-base-gpu-runtime/Dockerfile
+++ b/docker-base-gpu-runtime/Dockerfile
@@ -30,3 +30,6 @@ USER kat
 LABEL com.nvidia.volumes.needed="nvidia_driver" com.nvidia.cuda.version="10.0"
 # For nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=10.0
+
+# Just so that if the user passes the --build-arg they don't get a warning
+ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -39,14 +39,17 @@ RUN add-apt-repository -y ppa:kernsuite/kern-4 && \
         libcasa-python2 libcasa-scimath2 libcasa-tables2 casacore-data && \
     rm -rf /var/lib/apt/lists/*
 
+COPY mirror_wget /usr/local/bin/mirror_wget
+ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
+
 # Install some components of MLNX_OFED
 ENV MLNX_OFED_VERSION=4.3-1.0.1.0
 RUN cd /tmp && \
     MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu18.04-x86_64 && \
-    wget --progress=dot:mega http://sdp-services.kat.ac.za/mirror/www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
+    mirror_wget --progress=dot:mega https://www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
     tar -zxf $MLNX_OFED_PATH.tgz && \
     echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \
-    wget -qO - http://sdp-services.kat.ac.za/mirror/www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mirror_wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
     apt-get -y update && \
     apt-get install -y --no-install-recommends \
         libibverbs1 librdmacm1 libvma libmlx4-1 libmlx5-1 && \
@@ -58,7 +61,7 @@ RUN cd /tmp && \
 
 # Install tini (a mini-init) and set it as entrypoint so that we don't
 # accumulate zombie processes.
-RUN wget http://sdp-services.kat.ac.za/mirror/github.com/krallin/tini/releases/download/v0.18.0/tini -O /sbin/tini && \
+RUN mirror_wget https://github.com/krallin/tini/releases/download/v0.18.0/tini -O /sbin/tini && \
     chmod +x /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 

--- a/docker-base-runtime/mirror_wget
+++ b/docker-base-runtime/mirror_wget
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ -z "$KATSDPDOCKERBASE_MIRROR" ]; then
+    exec wget "$@"
+fi
+
+if ! curl -s -f -o /dev/null "$KATSDPDOCKERBASE_MIRROR"; then
+    echo "Warning: could not reach mirror $KATSDPDOCKERBASE_MIRROR; using original" 1>&2
+    exec wget "$@"
+fi
+
+declare -a args
+for arg; do
+    if [ "${arg#http://}" != "$arg" ]; then
+        arg="$KATSDPDOCKERBASE_MIRROR/${arg#http://}"
+    elif [ "${arg#https://}" != "$arg" ]; then
+        arg="$KATSDPDOCKERBASE_MIRROR/${arg#https://}"
+    fi
+    args+=("$arg")
+done
+exec wget "${args[@]}"


### PR DESCRIPTION
The default mirror (http://sdp-services.kat.ac.za/mirror) can be
overridden by passing `--build-arg KATSDPDOCKERBASE_MIRROR=<mirror>` on
the command line (can also be empty to disable the mirror entirely).

If the root URL of the mirror cannot be fetched, it falls back to no
mirroring. This should make it possible for anyone to build these images
even outside the SARAO offices.

Closes SR-1631.