### PR TITLE
Bump spead2 and pip to latest versions

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -82,7 +82,7 @@ scipy==1.1.0
 singledispatch==3.4.0.3
 six==1.12.0
 snowballstemmer==1.2.1
-spead2==1.13.1
+spead2==1.14.0
 sphinxcontrib-websupport==1.1.0
 sphinx-rtd-theme==0.4.2
 Sphinx==1.8.1

--- a/docker-base-build/pre-requirements.txt
+++ b/docker-base-build/pre-requirements.txt
@@ -1,6 +1,6 @@
-pip==19.0.3
-setuptools==41.0.0
-wheel==0.33.1
+pip==19.1.1
+setuptools==41.0.1
+wheel==0.33.4
 packaging==19.0
 pyparsing==2.4.0
 six==1.12.0


### PR DESCRIPTION
The spead2 bump is needed to fix OPS-67.