### PR TITLE
Update to KERN-5

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -58,7 +58,7 @@ netifaces==0.10.7
 nose==1.3.7
 numba==0.40.1
 numpy==1.15.3
-packaging==19.0
+packaging==19.1
 pandas==0.23.4
 pbr==1.8.1
 pkginfo==1.4.2
@@ -69,7 +69,7 @@ pyephem==3.7.6.0
 pygelf==0.3.6
 Pygments==2.0.2
 pyparsing==2.2.2
-python-casacore==2.0.0
+python-casacore==3.1.1
 python-dateutil==2.7.4
 python-lzf==0.2.4
 pytz==2018.7

--- a/docker-base-build/pre-requirements.txt
+++ b/docker-base-build/pre-requirements.txt
@@ -1,6 +1,6 @@
-pip==19.1.1
-setuptools==41.0.1
+pip==19.2.2
+setuptools==41.1.0
 wheel==0.33.4
-packaging==19.0
-pyparsing==2.4.0
+packaging==19.1
+pyparsing==2.4.2
 six==1.12.0

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -30,13 +30,10 @@ RUN apt-get -y update && apt-get --no-install-recommends -y install \
 # Install python-casacore run-time dependencies. Note that this cannot be
 # combined into the previous step because apt-add-repository is part of
 # software-properties-common, installed above.
-RUN add-apt-repository -y ppa:kernsuite/kern-4 && \
-    add-apt-repository -y multiverse && \
+RUN add-apt-repository -y ppa:kernsuite/kern-5 && \
     apt-get -y update && \
     apt-get --no-install-recommends -y install \
-        libcfitsio5 libwcs5 \
-        libcasa-casa2 libcasa-images2 libcasa-measures2 libcasa-ms2 \
-        libcasa-python2 libcasa-python3-2 libcasa-scimath2 libcasa-tables2 casacore-data && \
+        casacore-data && \
     rm -rf /var/lib/apt/lists/*
 
 COPY mirror_wget /usr/local/bin/mirror_wget


### PR DESCRIPTION
This is mostly in the hope that it will fix SPR1-172, but also because
KERN-4 is no longer supported and has known bugs.

Some Python packages are also updated:
- python-casacore is updated to the latest version, which has binary
  wheels that bundle casacore. For that reason, the casacore libraries
  are no longer installed in the runtime image, which should make it
  smaller.
- Bumped pip and friends to the latest version, just to stop pip warning
  that there is a newer version available.