### PR TITLE
Embed github's ssh public key

### DIFF
--- a/docker-base-build/Dockerfile
+++ b/docker-base-build/Dockerfile
@@ -40,7 +40,7 @@ USER kat
 
 # Set up access to github private repositories and set up git-lfs
 COPY --chown=kat:kat id_rsa /home/kat/.ssh/
-RUN echo "Host *\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config && \
+RUN echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts && \
     chmod -R go-rwx ~/.ssh && \
     git lfs install --skip-smudge
 


### PR DESCRIPTION
This is more secure than disabling strict host key checking (protects
against MITM attack).