### PR TITLE
Update katportalclient to 0.2.0

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -44,7 +44,7 @@ Jinja2==2.10.1
 jmespath==0.9.3
 jsonschema==2.6.0
 katcp==0.6.3; python_version<'3'
-katportalclient==0.1.1
+katportalclient==0.2.0
 katversion==0.9
 linecache2==1.0.0
 llvmlite==0.25.0


### PR DESCRIPTION
This is the version that supports katstore64, now (I believe?) deployed
on site.

There are backwards-incompatible API changes, but not in the subset of
the APIs we're using for SDP.