### PR TITLE
Make it easier to build against an alternate registry

### DIFF
--- a/docker-base-build/Dockerfile
+++ b/docker-base-build/Dockerfile
@@ -1,4 +1,7 @@
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-runtime
+ARG KATSDPDOCKERBASE_REGISTRY=sdp-docker-registry.kat.ac.za:5000
+ARG TAG=latest
+
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime:$TAG
 MAINTAINER Bruce Merry "bmerry@ska.ac.za"
 
 USER root

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -1,4 +1,7 @@
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-build
+ARG KATSDPDOCKERBASE_REGISTRY=sdp-docker-registry.kat.ac.za:5000
+ARG TAG=latest
+
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build:$TAG
 MAINTAINER Bruce Merry "bmerry@ska.ac.za"
 
 USER root

--- a/docker-base-gpu-runtime/Dockerfile
+++ b/docker-base-gpu-runtime/Dockerfile
@@ -1,4 +1,7 @@
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-runtime
+ARG KATSDPDOCKERBASE_REGISTRY=sdp-docker-registry.kat.ac.za:5000
+ARG TAG=latest
+
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime:$TAG
 MAINTAINER Bruce Merry "bmerry@ska.ac.za"
 
 USER root


### PR DESCRIPTION
The Dockerfiles are parametrised with the path to the registry, although
still defaulting to sdp-docker-registry. In future we could change
replace it with just a Dockerhub username for Dockerhub to build the
images. The Jenkins builder script takes the environment variable
DOCKER_REGISTRY (set in the Jenkins server configuration) and passes it
through.

As an added bonus, the build script also passes the tag being built, and
the Dockerfiles use that to specify the base image. This will fix the
problem of building branches of katsdpdockerbase itself, where
docker-base-build will be FROM docker-base-runtime:latest instead of
FROM docker-base-runtime:branch-being-built.