### PR TITLE
Use spead2 2.0.0 (on new enough Python versions)

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -84,7 +84,8 @@ scipy==1.1.0
 singledispatch==3.4.0.3
 six==1.12.0
 snowballstemmer==1.2.1
-spead2==1.14.0
+spead2==1.14.0; python_version<'3.5'
+spead2==2.0.0; python_version>='3.5'
 sphinxcontrib-websupport==1.1.0
 sphinx-rtd-theme==0.4.2
 Sphinx==1.8.1


### PR DESCRIPTION
It contains a fix that should help prevent ingest running out of memory.