### PR TITLE
Upgrade to MLNX OFED 4.7

### DIFF
--- a/docker-base-build/Dockerfile
+++ b/docker-base-build/Dockerfile
@@ -24,11 +24,11 @@ RUN cd /tmp && \
     MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu18.04-x86_64 && \
     mirror_wget --progress=dot:mega https://www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
     tar -zxf $MLNX_OFED_PATH.tgz && \
-    echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \
+    echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS/MLNX_LIBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \
     mirror_wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        libibverbs-dev librdmacm-dev libvma-dev && \
+        libibverbs-dev librdmacm-dev && \
     rm -rf "/tmp/$MLNX_OFED_PATH" \
         "/tmp/$MLNX_OFED_PATH.tgz" \
         /etc/apt/sources.list.d/mlnx-ofed.list \

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -40,16 +40,16 @@ COPY mirror_wget /usr/local/bin/mirror_wget
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
 
 # Install some components of MLNX_OFED
-ENV MLNX_OFED_VERSION=4.3-1.0.1.0
+ENV MLNX_OFED_VERSION=4.7-1.0.0.1
 RUN cd /tmp && \
     MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu18.04-x86_64 && \
     mirror_wget --progress=dot:mega https://www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
     tar -zxf $MLNX_OFED_PATH.tgz && \
-    echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \
+    echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS/MLNX_LIBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \
     mirror_wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
     apt-get -y update && \
     apt-get install -y --no-install-recommends \
-        libibverbs1 librdmacm1 libvma libmlx4-1 libmlx5-1 && \
+        libibverbs1 librdmacm1 libmlx4-1 libmlx5-1 && \
     rm -rf "/tmp/$MLNX_OFED_PATH" \
         "/tmp/$MLNX_OFED_PATH.tgz" \
         /etc/apt/sources.list.d/mlnx-ofed.list \


### PR DESCRIPTION
Fixes SPR1-329 (crash when run on lab machines). I've test this on site with katsdpingest and katcbfsim and it appears to be working with the older host driver/kernel used there.

I removed libvma because it created problems with the install (tried to use update-rc.d to enable a non-existent vma service) and we're not using it (it was used back when we ran ptuse inside SDP).