### PR TITLE
Drop Python 2 support from katsdpdockerbase

### DIFF
--- a/docker-base-build/Dockerfile
+++ b/docker-base-build/Dockerfile
@@ -8,7 +8,7 @@ USER root
 
 RUN apt-get -y update && apt-get --no-install-recommends -y install \
     build-essential pkg-config git-core ssh \
-    python-dev python3-dev \
+    python3-dev \
     libboost-program-options-dev \
     libboost-python-dev \
     libboost-system-dev \
@@ -50,22 +50,13 @@ RUN mkdir ~/.ssh && \
 COPY --chown=kat:kat *-requirements.txt /home/kat/docker-base/
 COPY install-requirements.py /usr/local/bin/
 # Pre-build a number of wheels to speed up building of dependent images.
-RUN virtualenv ~/tmp-ve && \
-    . ~/tmp-ve/bin/activate && \
-    pip install -r ~/docker-base/pre-requirements.txt && \
-    install-requirements.py -r ~/docker-base/base-requirements.txt && \
-    rm -r ~/tmp-ve
-# Same again for Python 3
 RUN virtualenv -p /usr/bin/python3 ~/tmp-ve3 && \
     . ~/tmp-ve3/bin/activate && \
     pip install -r ~/docker-base/pre-requirements.txt && \
     install-requirements.py -r ~/docker-base/base-requirements.txt && \
     rm -r ~/tmp-ve3
 
-# Create empty virtual environments for child images to install to
-RUN virtualenv ~/ve && \
-    . ~/ve/bin/activate && \
-    pip install -r ~/docker-base/pre-requirements.txt
+# Create empty virtual environment for child images to install to
 RUN virtualenv -p /usr/bin/python3 ~/ve3 && \
     . ~/ve3/bin/activate && \
     pip install -r ~/docker-base/pre-requirements.txt

--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -1,15 +1,15 @@
-aioconsole==0.1.10; python_version>='3'
+aioconsole==0.1.10
 # Note: aiohttp 3.x only supports Python 3.5.3+
-aiohttp==2.3.10; python_version>='3'
-aiokatcp==0.8.0; python_version>='3'
-aiomonitor==0.3.1; python_version>='3'
+aiohttp==2.3.10
+aiokatcp==0.8.0
+aiomonitor==0.3.1
 alabaster==0.7.12
 ansicolors==1.1.8
 appdirs==1.4.3
 argparse==1.4.0
 # Note: async-timeout 3.x only supports Python 3.5.3+
-async-timeout==2.0.1; python_version>='3'
-asynctest==0.12.2; python_version>='3'
+async-timeout==2.0.1
+asynctest==0.12.2
 attrs==18.2.0
 Babel==2.6.0
 backports-abc==0.5
@@ -30,7 +30,6 @@ docutils==0.14
 enum34==1.1.6
 fakeredis==0.13.1
 funcsigs==1.0.2
-functools32==3.2.3.post2; python_version<'3'
 future==0.17.1
 futures==3.1.1
 h5py==2.8.0
@@ -43,7 +42,6 @@ ipaddress==1.0.22
 Jinja2==2.10.1
 jmespath==0.9.3
 jsonschema==2.6.0
-katcp==0.6.3; python_version<'3'
 katportalclient==0.2.1
 katversion==0.9
 linecache2==1.0.0
@@ -54,7 +52,7 @@ MarkupSafe==0.23
 matplotlib==2.0.2
 mock==1.3.0
 msgpack==0.6.1
-multidict==4.1.0; python_version>='3'
+multidict==4.1.0
 netifaces==0.10.7
 nose==1.3.7
 numba==0.40.1
@@ -85,22 +83,20 @@ scipy==1.1.0
 singledispatch==3.4.0.3
 six==1.12.0
 snowballstemmer==1.2.1
-spead2==1.14.0; python_version<'3.5'
-spead2==2.0.2; python_version>='3.5'
+spead2==2.0.2
 sphinxcontrib-websupport==1.1.0
 sphinx-rtd-theme==0.4.2
 Sphinx==1.8.1
 subprocess32==3.5.3
-terminaltables==3.1.0; python_version>='3'
+terminaltables==3.1.0
 toolz==0.9.0
 # Note: tornado 5.x doesn't support trollius
 tornado==4.5.3
 traceback2==1.4.0
-trollius==2.1.post2
 typing==3.7.4.1
 typing_extensions==3.7.4.1
 ujson==1.35
 unittest2==1.1.0
 urllib3==1.25.3
 # Note: yarl 1.2+ requires Python 3.5.3+
-yarl==1.1.1; python_version>='3'
+yarl==1.1.1

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -25,7 +25,6 @@ RUN CUDA_RUN_FILE=cuda_10.0.130_410.48_linux && \
     rm -r /usr/local/cuda/libnvvp
 
 ENV PATH="$PATH:/usr/local/cuda/bin" \
-    PATH_PYTHON2="$PATH_PYTHON2:/usr/local/cuda/bin" \
     PATH_PYTHON3="$PATH_PYTHON3:/usr/local/cuda/bin"
 # /usr/lib/x86_64-linux-gnu is explicitly added to the front to prevent the
 # CUDA version of libOpenCL.so.1 (which is older) from overriding the version
@@ -42,19 +41,11 @@ USER kat
 
 # Create wheels for GPU-related packages
 COPY requirements.txt /home/kat/docker-base/gpu-requirements.txt
-RUN virtualenv ~/tmp-ve && \
-    . ~/tmp-ve/bin/activate && \
-    pip install -r ~/docker-base/pre-requirements.txt && \
-    install-requirements.py -d ~/docker-base/base-requirements.txt -r ~/docker-base/gpu-requirements.txt && \
-    rm -rf ~/tmp-ve
-# Same for Python3
 RUN virtualenv -p /usr/bin/python3 ~/tmp-ve3 && \
     . ~/tmp-ve3/bin/activate && \
     pip install -r ~/docker-base/pre-requirements.txt && \
     install-requirements.py -d ~/docker-base/base-requirements.txt -r ~/docker-base/gpu-requirements.txt && \
     rm -rf ~/tmp-ve3
 
-# For nvidia-docker 1.0
-LABEL com.nvidia.volumes.needed="nvidia_driver" com.nvidia.cuda.version="10.0"
 # For nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=10.0

--- a/docker-base-gpu-runtime/Dockerfile
+++ b/docker-base-gpu-runtime/Dockerfile
@@ -18,7 +18,6 @@ COPY --from=gpu-build /usr/local/cuda-10.0 /usr/local/cuda-10.0
 RUN ln -s /usr/local/cuda-10.0 /usr/local/cuda
 
 ENV PATH="$PATH:/usr/local/cuda/bin" \
-    PATH_PYTHON2="$PATH_PYTHON2:/usr/local/cuda/bin" \
     PATH_PYTHON3="$PATH_PYTHON3:/usr/local/cuda/bin"
 # /usr/lib/x86_64-linux-gnu is explicitly added to the front to prevent the
 # CUDA version of libOpenCL.so.1 (which is older) from overriding the version
@@ -32,8 +31,6 @@ RUN mkdir -p /etc/OpenCL/vendors && \
 
 USER kat
 
-# For nvidia-docker 1.0
-LABEL com.nvidia.volumes.needed="nvidia_driver" com.nvidia.cuda.version="10.0"
 # For nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=10.0
 

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -7,7 +7,7 @@ RUN gcc -o /usr/local/bin/schedrr /usr/local/src/schedrr.c -Wall -Wextra -s -O2
 
 #######################################################################
 
-FROM ubuntu:bionic-20191202
+FROM ubuntu:bionic-20190807
 LABEL maintainer="sdpdev+katsdpdockerbase@ska.ac.za"
 
 # Suppress debconf warnings

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -7,7 +7,7 @@ RUN gcc -o /usr/local/bin/schedrr /usr/local/src/schedrr.c -Wall -Wextra -s -O2
 
 #######################################################################
 
-FROM ubuntu:bionic-20190807
+FROM ubuntu:bionic-20191202
 LABEL maintainer="sdpdev+katsdpdockerbase@ska.ac.za"
 
 # Suppress debconf warnings
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && apt-get --no-install-recommends -y install \
         apt-transport-https gpg-agent \
         software-properties-common wget curl \
-        python python3 virtualenv \
+        python3 virtualenv \
         libboost-program-options1.65 \
         libboost-python1.65 \
         libboost-system1.65 \
@@ -76,6 +76,4 @@ USER kat
 # Define environment variables that child images can copy to PATH and
 # VIRTUAL_ENV to activate a virtual environment.
 ENV PATH_PYTHON3="/home/kat/ve3/bin:$PATH" \
-    PATH_PYTHON2="/home/kat/ve/bin:$PATH" \
-    VIRTUAL_ENV_PYTHON2="/home/kat/ve" \
     VIRTUAL_ENV_PYTHON3="/home/kat/ve3"


### PR DESCRIPTION
Now that Python 2 is EOL and most of our containers have migrated or are in the process of migrating, we can remove all the Python 2 baggage. I propose that we fork master into a `python2` legacy branch that will live only to support the last few containers, then merge this one and do all updates here.

I've avoided updating any versions of Python packages, although there are a number that can be upgraded to versions that have dropped Python 2 support.

I've marked this draft because we shouldn't merge before we've split out the python2 branch.