### PR TITLE
Add --create and --tmp to run_and_cleanup

### DIFF
--- a/docker-base-runtime/run-and-cleanup
+++ b/docker-base-runtime/run-and-cleanup
@@ -28,10 +28,7 @@ def main():
     args = parser.parse_args()
 
     if args.create:
-        try:
-            os.mkdir(args.path)
-        except FileExistsError:
-            pass
+        pathlib.Path(args.path).mkdir(parents=True, exist_ok=True)
 
     atexit.register(cleanup, args.path)
 

--- a/docker-base-runtime/run-and-cleanup
+++ b/docker-base-runtime/run-and-cleanup
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import os
 import signal
 import subprocess
 import sys
@@ -20,13 +21,25 @@ def main():
         description='Run a command and delete a path when it terminates. '
                     'Signals are forwarded to the executed process.',
         usage='%(prog)s path -- command [args...]')
+    parser.add_argument('-c', '--create', action='store_true', help='Create the path')
+    parser.add_argument('-t', '--tmp', action='store_true', help='Set as TMPDIR for child')
     parser.add_argument('path', help='Path to clean up')
     parser.add_argument('command', nargs='+', help='Command to run')
     args = parser.parse_args()
+
+    if args.create:
+        try:
+            os.mkdir(args.path)
+        except FileExistsError:
+            pass
+
     atexit.register(cleanup, args.path)
 
     try:
-        sub = subprocess.Popen(args.command)
+        env = dict(os.environ)
+        if args.tmp:
+            env['TMPDIR'] = args.path
+        sub = subprocess.Popen(args.command, env=env)
     except OSError as exc:
         print(exc, file=sys.stderr)
         sys.exit(127)


### PR DESCRIPTION
The former allows the directory to be created if it does not already
exist, and the latter sets it as TMPDIR. Together they make it easier to
run a task and have it place temporary files in a specific location
(e.g. on a particular mount) without modifying it.