### PR TITLE
Add pytest to base-requirements

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -41,6 +41,7 @@ mako==1.1.1
 manhole==1.6.0                         # TODO: only used by katsdpdisp - could remove
 MarkupSafe==1.1.1                      # via jinja2, mako
 matplotlib==3.1.3
+more-itertools==8.3.0                  # via pytest
 msgpack==0.6.2
 multidict==4.7.4                       # via yarl, aiohttp
 netifaces==0.10.9
@@ -52,12 +53,16 @@ omnijson==0.1.2                        # via katportalclient
 packaging==20.1                        # via sphinx, bokeh
 pandas==1.0.1
 pillow==7.0.0                          # via bokeh
+pluggy==0.13.1                         # via pytest
 pyephem==3.7.7.0                       # via pyephem
 pygelf==0.3.6
 Pygments==2.5.2                        # via sphinx
+py==1.8.1                              # via pytest
 pyjwt==1.7.1
 pyparsing==2.4.6                       # via packaging, matplotlib
 pyrsistent==0.15.5                     # via jsonschema
+pytest==5.3.5
+pytest-cov==2.9.0
 python-casacore==3.2.0
 python-dateutil==2.8.1
 python-lzf==0.2.4
@@ -87,5 +92,6 @@ typing==3.7.4.1
 typing_extensions==3.7.4.1
 ujson==2.0.3                           # via katportalclient
 urllib3==1.25.8                        # via requests
+wcwidth==0.2.3                         # via pytest
 yarl==1.4.2                            # via aiohttp
 zipp==2.2.0                            # via importlib-metadata


### PR DESCRIPTION
This will make it easier to use pytest for testing in packages (and also needed for ska-sa/katsdpcookiecutter#1).