### PR TITLE
Add strict-rfc3339 to requirements

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -86,6 +86,7 @@ sphinxcontrib-serializinghtml==1.1.3   # via sphinx
 sphinxcontrib-websupport==1.2.0        # via sphinx
 sphinx-rtd-theme==0.4.3
 Sphinx==2.4.1
+strict-rfc3339==0.7
 terminaltables==3.1.0                  # via aiomonitor
 toolz==0.10.0                          # via dask
 tornado==6.0.3


### PR DESCRIPTION
It's used by katsdpmodels.