### PR TITLE
Fix image reference from which to copy CUDA

### DIFF
--- a/docker-base-gpu-runtime/Dockerfile
+++ b/docker-base-gpu-runtime/Dockerfile
@@ -2,7 +2,7 @@ ARG KATSDPDOCKERBASE_REGISTRY=sdp-docker-registry.kat.ac.za:5000
 ARG TAG=latest
 
 # Just to give it a name to refer to for the later COPY step
-FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-gpu-build as gpu-build
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-gpu-build:$TAG as gpu-build
 
 FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime:$TAG
 LABEL maintainer="sdpdev+katsdpdockerbase@ska.ac.za"


### PR DESCRIPTION
When building a branch, it was copying the CUDA installation from
latest instead of the branch.