### PR TITLE
Use upstream rdma-core instead of MLNX-OFED 4.x

### DIFF
--- a/docker-base-build/Dockerfile
+++ b/docker-base-build/Dockerfile
@@ -19,22 +19,6 @@ RUN apt-get -y update && apt-get --no-install-recommends -y install \
 
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
 
-# Install dev libraries from MLNX OFED
-RUN cd /tmp && \
-    MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu18.04-x86_64 && \
-    mirror_wget --progress=dot:mega https://www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
-    tar -zxf $MLNX_OFED_PATH.tgz && \
-    echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS/MLNX_LIBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \
-    mirror_wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        libibverbs-dev librdmacm-dev && \
-    rm -rf "/tmp/$MLNX_OFED_PATH" \
-        "/tmp/$MLNX_OFED_PATH.tgz" \
-        /etc/apt/sources.list.d/mlnx-ofed.list \
-        /var/lib/apt/lists/* \
-        /tmp/vma
-
 # Install git-lfs
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
     apt-get install git-lfs

--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -77,7 +77,7 @@ scipy==1.4.1
 six==1.14.0
 snowballstemmer==2.0.0                 # via sphinx
 sortedcontainers==2.1.0                # via fakeredis
-spead2==2.0.2
+spead2==3.0.1
 sphinxcontrib-applehelp==1.0.1         # via sphinx
 sphinxcontrib-devhelp==1.0.1           # via shpinx
 sphinxcontrib-htmlhelp==1.0.2          # via sphinx

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -25,12 +25,12 @@ RUN CUDA_RUN_FILE=cuda_10.0.130_410.48_linux && \
     rm -r /usr/local/cuda/libnvvp
 
 ENV PATH="$PATH:/usr/local/cuda/bin" \
-    PATH_PYTHON3="$PATH_PYTHON3:/usr/local/cuda/bin"
-# /usr/lib/x86_64-linux-gnu is explicitly added to the front to prevent the
-# CUDA version of libOpenCL.so.1 (which is older) from overriding the version
-# installed by ocl-icd-opencl-dev.
-ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:/usr/local/cuda/lib64"
-ENV LIBRARY_PATH="/usr/local/cuda/lib64"
+    PATH_PYTHON3="$PATH_PYTHON3:/usr/local/cuda/bin" \
+    LIBRARY_PATH="/usr/local/cuda/lib64"
+# Calling the file z_cuda puts it behind the system libraries in search
+# order, which ensures that the system version of libOpenCL.so.1 (which is
+# newer) is found in preference to the one provided with CUDA).
+RUN echo '/usr/local/cuda/lib64' > /etc/ld.so.conf.d/z_cuda.conf && ldconfig
 
 # Create information for locating the NVIDIA driver components. This isn't handled
 # by nvidia-docker.

--- a/docker-base-gpu-runtime/Dockerfile
+++ b/docker-base-gpu-runtime/Dockerfile
@@ -19,13 +19,13 @@ RUN ln -s /usr/local/cuda-10.0 /usr/local/cuda
 
 ENV PATH="$PATH:/usr/local/cuda/bin" \
     PATH_PYTHON3="$PATH_PYTHON3:/usr/local/cuda/bin"
-# /usr/lib/x86_64-linux-gnu is explicitly added to the front to prevent the
-# CUDA version of libOpenCL.so.1 (which is older) from overriding the version
-# installed by ocl-icd-opencl-dev.
-ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:/usr/local/cuda/lib64"
+# Calling the file z_cuda puts it behind the system libraries in search
+# order, which ensures that the system version of libOpenCL.so.1 (which is
+# newer) is found in preference to the one provided with CUDA).
+RUN echo '/usr/local/cuda/lib64' > /etc/ld.so.conf.d/z_cuda.conf && ldconfig
 
 # Create information for locating the NVIDIA driver components. This isn't handled
-# by nvidia-docker.
+# by nvidia-container-runtime.
 RUN mkdir -p /etc/OpenCL/vendors && \
     echo libnvidia-opencl.so.1 > /etc/OpenCL/vendors/nvidia.icd
 

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -5,6 +5,35 @@ RUN apt-get -y update && apt-get -y install gcc
 COPY schedrr.c /usr/local/src
 RUN gcc -o /usr/local/bin/schedrr /usr/local/src/schedrr.c -Wall -Wextra -s -O2
 
+# A temporary stage just to compile rdma-core
+# The steps are loosely based on the rdma-core README.md and debian/rules.
+FROM ubuntu:bionic-20200112 as build-rdma-core
+RUN apt-get -y update && apt-get -y install \
+    wget \
+    build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev \
+    ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc
+WORKDIR /tmp
+RUN wget https://github.com/linux-rdma/rdma-core/releases/download/v31.0/rdma-core-31.0.tar.gz
+RUN tar -zxf rdma-core-31.0.tar.gz && \
+    mkdir rdma-core-31.0/build && \
+    cd rdma-core-31.0/build && \
+    cmake \
+        -GNinja \
+        -DDISTRO_FLAVOUR=Debian \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+        -DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc \
+        -DCMAKE_INSTALL_SYSTEMD_SERVICEDIR:PATH=/lib/systemd/system \
+        -DCMAKE_INSTALL_INITDDIR:PATH=/etc/init.d \
+        -DCMAKE_INSTALL_LIBEXECDIR:PATH=/usr/lib \
+        -DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=/var/lib \
+        -DCMAKE_INSTALL_RUNDIR:PATH=/run \
+        -DCMAKE_INSTALL_UDEV_RULESDIR:PATH=/lib/udev/rules.d \
+        -DCMAKE_INSTALL_PERLDIR:PATH=/usr/share/perl5 \
+        -DNO_PYVERBS=1 \
+        .. && \
+    DESTDIR=/tmp/rdma-core ninja install
+
 #######################################################################
 
 FROM ubuntu:bionic-20200112
@@ -24,7 +53,8 @@ RUN apt-get -y update && apt-get --no-install-recommends -y install \
         libboost-python1.65 \
         libboost-system1.65 \
         libboost-regex1.65 \
-        netbase && \
+        netbase \
+        libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install python-casacore run-time dependencies. Note that this cannot be
@@ -39,23 +69,6 @@ RUN add-apt-repository -y ppa:kernsuite/kern-5 && \
 COPY mirror_wget /usr/local/bin/mirror_wget
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
 
-# Install some components of MLNX_OFED
-ENV MLNX_OFED_VERSION=4.7-1.0.0.1
-RUN cd /tmp && \
-    MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu18.04-x86_64 && \
-    mirror_wget --progress=dot:mega https://www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
-    tar -zxf $MLNX_OFED_PATH.tgz && \
-    echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS/MLNX_LIBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \
-    mirror_wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
-    apt-get -y update && \
-    apt-get install -y --no-install-recommends \
-        libibverbs1 librdmacm1 libmlx4-1 libmlx5-1 && \
-    rm -rf "/tmp/$MLNX_OFED_PATH" \
-        "/tmp/$MLNX_OFED_PATH.tgz" \
-        /etc/apt/sources.list.d/mlnx-ofed.list \
-        /var/lib/apt/lists/* \
-        /tmp/vma
-
 # Install tini (a mini-init) and set it as entrypoint so that we don't
 # accumulate zombie processes.
 RUN mirror_wget https://github.com/krallin/tini/releases/download/v0.18.0/tini -O /sbin/tini && \
@@ -67,6 +80,8 @@ COPY --from=build-schedrr /usr/local/bin/schedrr /usr/local/bin/schedrr
 RUN chmod u+s /usr/local/bin/schedrr
 # A helper script to run a program then clean up its scratch space
 COPY run-and-cleanup /usr/local/bin/run-and-cleanup
+# Install rdma-core from build image
+COPY --from=build-rdma-core /tmp/rdma-core/ /
 
 # Create and switch to a user which will be used to run commands with reduced
 # privileges.

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -1,17 +1,24 @@
-# A temporary stage just to compile schedrr
-FROM ubuntu:bionic-20200112 as build-schedrr
-RUN apt-get -y update && apt-get -y install gcc
+# A temporary stage just for compiling things
+FROM ubuntu:bionic-20200112 as build
+RUN apt-get -y update && apt-get -y install \
+    wget \
+    build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev \
+    ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc \
+    libcap-dev
+
 # Create a setuid binary to assist with realtime scheduling
 COPY schedrr.c /usr/local/src
 RUN gcc -o /usr/local/bin/schedrr /usr/local/src/schedrr.c -Wall -Wextra -s -O2
 
-# A temporary stage just to compile rdma-core
-# The steps are loosely based on the rdma-core README.md and debian/rules.
-FROM ubuntu:bionic-20200112 as build-rdma-core
-RUN apt-get -y update && apt-get -y install \
-    wget \
-    build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev \
-    ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc
+# Create a utility to allow increasing privileges where needed. Individual
+# containers should use 'setcap /usr/local/bin/capambel cap_xxx+i' to grant
+# the necessary privileges (and also run Docker with --cap-add where
+# necessary).
+COPY capambel.c /usr/local/src
+RUN gcc -o /usr/local/bin/capambel /usr/local/src/capambel.c -Wall -Wextra -s -O2 -lcap
+
+# Install rdma-core. The steps are loosely based on the rdma-core README.md and
+# debian/rules.
 WORKDIR /tmp
 RUN wget https://github.com/linux-rdma/rdma-core/releases/download/v31.0/rdma-core-31.0.tar.gz
 RUN tar -zxf rdma-core-31.0.tar.gz && \
@@ -54,6 +61,8 @@ RUN apt-get -y update && apt-get --no-install-recommends -y install \
         libboost-system1.65 \
         libboost-regex1.65 \
         netbase \
+        libcap2 \
+        libcap2-bin \
         libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/*
 
@@ -76,12 +85,14 @@ RUN mirror_wget https://github.com/krallin/tini/releases/download/v0.18.0/tini -
 ENTRYPOINT ["/sbin/tini", "--"]
 
 # Create a setuid binary to assist with realtime scheduling
-COPY --from=build-schedrr /usr/local/bin/schedrr /usr/local/bin/schedrr
+COPY --from=build /usr/local/bin/schedrr /usr/local/bin/schedrr
 RUN chmod u+s /usr/local/bin/schedrr
+# A helper for gaining Linux capabilities
+COPY --from=build /usr/local/bin/capambel /usr/local/bin/capambel
 # A helper script to run a program then clean up its scratch space
 COPY run-and-cleanup /usr/local/bin/run-and-cleanup
 # Install rdma-core from build image
-COPY --from=build-rdma-core /tmp/rdma-core/ /
+COPY --from=build /tmp/rdma-core/ /
 
 # Create and switch to a user which will be used to run commands with reduced
 # privileges.

--- a/docker-base-runtime/capambel.c
+++ b/docker-base-runtime/capambel.c
@@ -1,0 +1,134 @@
+/* Copyright (c) 2020, National Research Foundation (SARAO)
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Transfers permitted capabilities to the ambient set, then executes
+ * another program. To use
+ *
+ * 1. Compile by running 'make'.
+ * 2. Make the program executable by only the user/group you want to use it.
+ * 3. Grant the program the capabilities that it should pass on e.g.
+ *    setcap cap_net_raw+p capambel.
+ *
+ * By default it applies all permitted capabilities, but the -c option can
+ * be used to give a capability specification, as parsed by cap_to_text(3),
+ * from which permitted capabilities will be taken.
+ */
+
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+#include <stdio.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <sys/capability.h>
+#include <sys/prctl.h>
+
+static void check(int result, const char *name)
+{
+    if (result != 0)
+    {
+        perror(name);
+        exit(1);
+    }
+}
+
+static void check_ptr(void *ptr, const char *name)
+{
+    if (ptr == NULL)
+    {
+        perror(name);
+        exit(1);
+    }
+}
+
+static void usage(void)
+{
+    fputs("Usage: capambel [-v] [-c cap,...,cap+p] -- <program> [<args>...]\n", stderr);
+    exit(2);
+}
+
+int main(int argc, char * const argv[])
+{
+    static const struct option options[] =
+    {
+        {"verbose", no_argument, 0, 'v'},
+        {"capabilities", required_argument, 0, 'c'},
+        {0, 0, 0, 0}
+    };
+
+    cap_t cap = NULL;
+    cap_value_t value;
+    int opt;
+    bool verbose = false;
+
+    /* No options yet, but make provision for them */
+    do
+    {
+        switch (opt = getopt_long(argc, argv, "vc:", options, NULL))
+        {
+        case -1:
+            break;
+        case 'v':
+            verbose = true;
+            break;
+        case 'c':
+            cap = cap_from_text(optarg);
+            check_ptr(cap, "cap_from_text");
+            break;
+        default:
+            usage();
+        }
+    } while (opt != -1);
+    if (optind >= argc)
+        usage();
+
+    if (!cap)
+    {
+        cap = cap_get_proc();
+        check_ptr(cap, "cap_get_proc");
+    }
+
+    for (value = 0; value <= CAP_LAST_CAP; value++)
+    {
+        cap_flag_value_t state;
+        check(cap_get_flag(cap, value, CAP_PERMITTED, &state), "cap_get_flag");
+        if (state)
+        {
+            /* Ambient flag can only be raised if the flag is inheritable. */
+            check(cap_set_flag(cap, CAP_INHERITABLE, 1, &value, CAP_SET), "cap_set_flag");
+            check(cap_set_proc(cap), "cap_set_proc");
+            /* Older versions of libcap don't support cap_set_ambient, so use
+             * prctl directly.
+             */
+            check(prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, value, 0, 0), "prctl");
+            if (verbose)
+            {
+                char *name;
+                name = cap_to_name(value);
+                check_ptr(name, "cap_to_name");
+                fprintf(stderr, "Added %s to ambient set\n", name);
+                cap_free(name);
+            }
+        }
+    }
+    cap_free(cap);
+
+    execvp(argv[optind], argv + optind);
+    perror("execvp");
+    return 1;
+}


### PR DESCRIPTION
This makes it play nice with spead2 3.x.

To support newer mlx5 kernel modules, add a utility program (capambel) which can set ambient capabilities. Child images that need such capabilities (currently just katcbfsim, since it doesn't seem to be needed for receive) use setcap to grant capambel the capability. An alternative would be to just grant the Python binary the capability directly. I'm not sure which approach is better, so feedback is welcome. Having a separate utility means that
(a) it can be used to run other tools inside the container (e.g. spead2_recv binary);
(b) if the capability isn't present for some reason (e.g. if the Docker storage backend doesn't support capabilities), capambel will fail early, rather than a somewhat cryptic error when trying to capture-start.
The disadvantage is extra complexity, both in having the script in the first place, and in the master controller having to call it.