### PR TITLE
Update to Ubuntu 20.04

### DIFF
--- a/docker-base-build/Dockerfile
+++ b/docker-base-build/Dockerfile
@@ -21,7 +21,7 @@ ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
 
 # Install dev libraries from MLNX OFED
 RUN cd /tmp && \
-    MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu18.04-x86_64 && \
+    MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu20.04-x86_64 && \
     mirror_wget --progress=dot:mega https://www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
     tar -zxf $MLNX_OFED_PATH.tgz && \
     echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS/MLNX_LIBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \

--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -1,5 +1,5 @@
 aioconsole==0.1.15                     # via aiomonitor
-aiohttp==3.6.2
+aiohttp==3.7.3
 aiohttp-retry==2.0
 aiokatcp==0.8.0
 aiomonitor==0.4.5

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -17,10 +17,11 @@ RUN CUDA_RUN_FILE=cuda_11.0.1_450.36.06_linux.run && \
     sh ./$CUDA_RUN_FILE --silent --toolkit && \
     rm -- $CUDA_RUN_FILE && \
     rm -r /usr/local/cuda/doc && \
-    rm -r /usr/local/cuda/tools && \
     rm -r /usr/local/cuda/extras && \
-    rm -r /usr/local/cuda/libnsight && \
-    rm -r /usr/local/cuda/libnvvp
+    rm -r /usr/local/cuda/libnvvp && \
+    rm -r /usr/local/cuda/nsight* && \
+    rm -r /usr/local/cuda/Sanitizer && \
+    rm -r /usr/local/cuda/tools
 
 ENV PATH="$PATH:/usr/local/cuda/bin" \
     PATH_PYTHON3="$PATH_PYTHON3:/usr/local/cuda/bin"

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y \
 
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
 
-RUN CUDA_RUN_FILE=cuda_10.2.89_440.33.01_linux.run && \
-    mirror_wget --progress=dot:mega "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/$CUDA_RUN_FILE" && \
+RUN CUDA_RUN_FILE=cuda_11.0.1_450.36.06_linux.run && \
+    mirror_wget --progress=dot:mega "http://developer.download.nvidia.com/compute/cuda/11.0.1/local_installers/$CUDA_RUN_FILE" && \
     sh ./$CUDA_RUN_FILE --silent --toolkit && \
-    rm -- $CUDA_RUN_FILE /tmp/cuda* && \
+    rm -- $CUDA_RUN_FILE && \
     rm -r /usr/local/cuda/doc && \
     rm -r /usr/local/cuda/samples && \
     rm -r /usr/local/cuda/tools && \

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -17,7 +17,6 @@ RUN CUDA_RUN_FILE=cuda_11.0.1_450.36.06_linux.run && \
     sh ./$CUDA_RUN_FILE --silent --toolkit && \
     rm -- $CUDA_RUN_FILE && \
     rm -r /usr/local/cuda/doc && \
-    rm -r /usr/local/cuda/samples && \
     rm -r /usr/local/cuda/tools && \
     rm -r /usr/local/cuda/extras && \
     rm -r /usr/local/cuda/jre && \

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y \
 
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
 
-RUN CUDA_RUN_FILE=cuda_10.0.130_410.48_linux && \
-    mirror_wget --progress=dot:mega "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/$CUDA_RUN_FILE" && \
+RUN CUDA_RUN_FILE=cuda_10.2.89_440.33.01_linux.run && \
+    mirror_wget --progress=dot:mega "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/$CUDA_RUN_FILE" && \
     sh ./$CUDA_RUN_FILE --silent --toolkit && \
     rm -- $CUDA_RUN_FILE /tmp/cuda* && \
     rm -r /usr/local/cuda/doc && \
@@ -48,4 +48,4 @@ RUN virtualenv -p /usr/bin/python3 ~/tmp-ve3 && \
     rm -rf ~/tmp-ve3
 
 # For nvidia-container-runtime
-ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=10.0
+ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=10.2

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -19,7 +19,6 @@ RUN CUDA_RUN_FILE=cuda_11.0.1_450.36.06_linux.run && \
     rm -r /usr/local/cuda/doc && \
     rm -r /usr/local/cuda/tools && \
     rm -r /usr/local/cuda/extras && \
-    rm -r /usr/local/cuda/jre && \
     rm -r /usr/local/cuda/libnsight && \
     rm -r /usr/local/cuda/libnvvp
 

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y \
 
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
 
-RUN CUDA_RUN_FILE=cuda_11.0.1_450.36.06_linux.run && \
-    mirror_wget --progress=dot:mega "http://developer.download.nvidia.com/compute/cuda/11.0.1/local_installers/$CUDA_RUN_FILE" && \
+RUN CUDA_RUN_FILE=cuda_11.0.2_450.51.05_linux.run && \
+    mirror_wget --progress=dot:mega "http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/$CUDA_RUN_FILE" && \
     sh ./$CUDA_RUN_FILE --silent --toolkit && \
     rm -- $CUDA_RUN_FILE && \
     rm -r /usr/local/cuda/doc && \
@@ -47,4 +47,4 @@ RUN virtualenv -p /usr/bin/python3 ~/tmp-ve3 && \
     rm -rf ~/tmp-ve3
 
 # For nvidia-container-runtime
-ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=10.2
+ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=11.0

--- a/docker-base-gpu-runtime/Dockerfile
+++ b/docker-base-gpu-runtime/Dockerfile
@@ -2,7 +2,7 @@ ARG KATSDPDOCKERBASE_REGISTRY=sdp-docker-registry.kat.ac.za:5000
 ARG TAG=latest
 
 # Just to give it a name to refer to for the later COPY step
-FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-gpu-build as gpu-build
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-gpu-build:$TAG as gpu-build
 
 FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-runtime:$TAG
 LABEL maintainer="sdpdev+katsdpdockerbase@ska.ac.za"

--- a/docker-base-gpu-runtime/Dockerfile
+++ b/docker-base-gpu-runtime/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y \
         g++ ocl-icd-libopencl1 && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=gpu-build /usr/local/cuda-10.0 /usr/local/cuda-10.0
-RUN ln -s /usr/local/cuda-10.0 /usr/local/cuda
+COPY --from=gpu-build /usr/local/cuda-11.0 /usr/local/cuda-11.0
+RUN ln -s /usr/local/cuda-11.0 /usr/local/cuda
 
 ENV PATH="$PATH:/usr/local/cuda/bin" \
     PATH_PYTHON3="$PATH_PYTHON3:/usr/local/cuda/bin"

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -63,17 +63,9 @@ RUN apt-get -y update && apt-get --no-install-recommends -y install \
         netbase \
         libcap2 \
         libcap2-bin \
-        libnl-3-200 libnl-route-3-200 && \
+        libnl-3-200 libnl-route-3-200 \
+        casacore-data && \
     rm -rf /var/lib/apt/lists/*
-
-# Install python-casacore run-time dependencies. Note that this cannot be
-# combined into the previous step because apt-add-repository is part of
-# software-properties-common, installed above.
-#RUN add-apt-repository -y ppa:kernsuite/kern-5 && \
-#    apt-get -y update && \
-#    apt-get --no-install-recommends -y install \
-#        casacore-data && \
-#    rm -rf /var/lib/apt/lists/*
 
 COPY mirror_wget /usr/local/bin/mirror_wget
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -1,5 +1,5 @@
 # A temporary stage just to compile schedrr
-FROM ubuntu:bionic-20200112 as build-schedrr
+FROM ubuntu:focal-20200423 as build-schedrr
 RUN apt-get -y update && apt-get -y install gcc
 # Create a setuid binary to assist with realtime scheduling
 COPY schedrr.c /usr/local/src
@@ -7,7 +7,7 @@ RUN gcc -o /usr/local/bin/schedrr /usr/local/src/schedrr.c -Wall -Wextra -s -O2
 
 #######################################################################
 
-FROM ubuntu:bionic-20200112
+FROM ubuntu:focal-20200423
 LABEL maintainer="sdpdev+katsdpdockerbase@ska.ac.za"
 
 # Suppress debconf warnings
@@ -20,29 +20,29 @@ RUN apt-get -y update && apt-get --no-install-recommends -y install \
         apt-transport-https gpg-agent \
         software-properties-common wget curl \
         python3 virtualenv \
-        libboost-program-options1.65 \
-        libboost-python1.65 \
-        libboost-system1.65 \
-        libboost-regex1.65 \
+        libboost-program-options1.71.0 \
+        libboost-python1.71.0 \
+        libboost-system1.71.0 \
+        libboost-regex1.71.0 \
         netbase && \
     rm -rf /var/lib/apt/lists/*
 
 # Install python-casacore run-time dependencies. Note that this cannot be
 # combined into the previous step because apt-add-repository is part of
 # software-properties-common, installed above.
-RUN add-apt-repository -y ppa:kernsuite/kern-5 && \
-    apt-get -y update && \
-    apt-get --no-install-recommends -y install \
-        casacore-data && \
-    rm -rf /var/lib/apt/lists/*
+#RUN add-apt-repository -y ppa:kernsuite/kern-5 && \
+#    apt-get -y update && \
+#    apt-get --no-install-recommends -y install \
+#        casacore-data && \
+#    rm -rf /var/lib/apt/lists/*
 
 COPY mirror_wget /usr/local/bin/mirror_wget
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
 
 # Install some components of MLNX_OFED
-ENV MLNX_OFED_VERSION=4.7-1.0.0.1
+ENV MLNX_OFED_VERSION=4.9-0.1.7.0
 RUN cd /tmp && \
-    MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu18.04-x86_64 && \
+    MLNX_OFED_PATH=MLNX_OFED_LINUX-$MLNX_OFED_VERSION-ubuntu20.04-x86_64 && \
     mirror_wget --progress=dot:mega https://www.mellanox.com/downloads/ofed/MLNX_OFED-$MLNX_OFED_VERSION/$MLNX_OFED_PATH.tgz && \
     tar -zxf $MLNX_OFED_PATH.tgz && \
     echo "deb file:///tmp/$MLNX_OFED_PATH/DEBS/MLNX_LIBS ./" > /etc/apt/sources.list.d/mlnx-ofed.list && \

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -1,6 +1,6 @@
 # A temporary stage just for compiling things
 FROM ubuntu:focal-20201106 as build
-RUN apt-get -y update && apt-get -y install \
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     wget \
     build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev \
     ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc \
@@ -92,7 +92,12 @@ COPY --from=build /usr/local/bin/capambel /usr/local/bin/capambel
 # A helper script to run a program then clean up its scratch space
 COPY run-and-cleanup /usr/local/bin/run-and-cleanup
 # Install rdma-core from build image
-COPY --from=build /tmp/rdma-core/ /
+# We have to copy each subdirectory individually, because the 20.04 image
+# symlinks /lib -> /usr/lib etc, and https://github.com/moby/moby/issues/41035
+# causes the symlinks to be overwritten if we try to copy to the root.
+COPY --from=build /tmp/rdma-core/etc /etc
+COPY --from=build /tmp/rdma-core/lib /lib
+COPY --from=build /tmp/rdma-core/usr /usr
 
 # Create and switch to a user which will be used to run commands with reduced
 # privileges.

--- a/docker-base-runtime/Dockerfile
+++ b/docker-base-runtime/Dockerfile
@@ -1,5 +1,5 @@
 # A temporary stage just for compiling things
-FROM ubuntu:focal-2020423 as build
+FROM ubuntu:focal-20201106 as build
 RUN apt-get -y update && apt-get -y install \
     wget \
     build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev \
@@ -43,7 +43,7 @@ RUN tar -zxf rdma-core-31.0.tar.gz && \
 
 #######################################################################
 
-FROM ubuntu:focal-20200423
+FROM ubuntu:focal-20201106
 LABEL maintainer="sdpdev+katsdpdockerbase@ska.ac.za"
 
 # Suppress debconf warnings


### PR DESCRIPTION
Most of the updates are to bump to versions that work on Ubuntu 20.04 or Python 3.8 (including CUDA). I also had to remove KERN because there isn't a version supporting 20.04 yet.

Don't merge yet: there are a number of other images that need matching changes to be merged at the same time.