### PR TITLE
Downgrade numba to 0.51.2

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -38,7 +38,7 @@ jsonschema==3.2.0
 katportalclient==0.2.2
 katversion==1.1
 kiwisolver==1.3.1                      # via matplotlib
-llvmlite==0.35.0                       # via numba
+llvmlite==0.34.0                       # via numba
 mako==1.1.4
 manhole==1.6.0                         # TODO: only used by katsdpdisp - could remove
 markupsafe==1.1.1                      # via jinja2, mako
@@ -47,7 +47,7 @@ msgpack==1.0.2
 multidict==5.1.0                       # via yarl, aiohttp
 netifaces==0.10.9
 nose==1.3.7
-numba==0.52.0
+numba==0.51.2                          # Not the latest due to https://github.com/numba/numba/issues/6819
 numpy==1.20.1
 omnijson==0.1.2                        # via katportalclient
 packaging==20.9                        # via sphinx, bokeh, pytest


### PR DESCRIPTION
Newer versions suffer from https://github.com/numba/numba/issues/6819,
which is affecting katsdpcal.