### PR TITLE
Downgrade dask to 2.27

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -20,7 +20,10 @@ chardet==3.0.4                         # via requests, aiohttp (not 4.x due to a
 cityhash==0.2.3.post9
 coverage==5.5
 cycler==0.10.0                         # via matplotlib
-dask==2.30                             # Not the latest due to https://github.com/dask/dask/issues/7402
+# Not the latest dask due to several bugs:
+# https://github.com/dask/dask/issues/7402
+# https://github.com/dask/dask/issues/7632
+dask==2.27
 decorator==4.4.2
 defusedxml==0.6.0
 docutils==0.16


### PR DESCRIPTION
To avoid being impacted by https://github.com/dask/dask/issues/7632.