### PR TITLE
Fix for NVIDIA 460.xx drivers

### DIFF
--- a/docker-base-gpu-runtime/Dockerfile
+++ b/docker-base-gpu-runtime/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p /etc/OpenCL/vendors && \
 USER kat
 
 # For nvidia-container-runtime
-ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=11.3
+ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=11.0
 
 # Just so that if the user passes the --build-arg they don't get a warning
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror


### PR DESCRIPTION
This was broken by #71, which upgraded CUDA to 11.3.1 and also set
`NVIDIA_REQUIRE_CUDA>=11.3` in the runtime image. The meaning of this
setting is a bit murky, but I believe that each driver release reports a
version of CUDA is supports, and this is compared before starting the
container. The 460.39 drivers deployed on site advertise support for
CUDA 11.2, but according to the CUDA release notes, CUDA 11.0 to 11.4
all have the same requirement: 450.80.02 or later.

Since all CUDA 11 versions have the same minimum requirement, I've
changed NVIDIA_REQUIRE_CUDA to 11.0 (which matches what was in the build
image).