### PR TITLE
Bump aiokatcp to 1.5.0

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -1,7 +1,7 @@
 aioconsole==0.3.1                      # via aiomonitor
 aiohttp==3.8.1
 aiohttp-retry==2.3.3
-aiokatcp==1.3.1
+aiokatcp==1.5.0
 aiomonitor==0.4.5
 aioredis==2.0.0
 aiosignal==1.2.0                       # via aiohttp


### PR DESCRIPTION
This contains features that are due to be used in katsdpcontroller, but also some bugfixes so all packages might as well benefit.