### PR TITLE
Bump some vulnerable versions in base-requirements

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -16,7 +16,7 @@ attrs==20.3.0
 Babel==2.9.1                           # via sphinx
 bokeh==2.3.0
 botocore==1.19.52                      # Not the latest due to aiobotocore restriction
-certifi==2020.12.5                     # via requests
+certifi==2022.12.7                     # via requests
 chardet==3.0.4                         # via requests, aiohttp (not 4.x due to aiohttp restriction)
 charset-normalizer==2.0.12             # via aiohttp
 cityhash==0.2.3.post9
@@ -45,9 +45,9 @@ katportalclient==0.2.2
 katversion==1.1
 kiwisolver==1.3.1                      # via matplotlib
 llvmlite==0.34.0                       # via numba
-mako==1.1.4
+mako==1.2.2
 manhole==1.6.0                         # TODO: only used by katsdpdisp - could remove
-markupsafe==1.1.1                      # via jinja2, mako
+markupsafe==2.1.2                      # via jinja2, mako
 matplotlib==3.3.4
 msgpack==1.0.2
 multidict==5.1.0                       # via yarl, aiohttp
@@ -60,7 +60,7 @@ numpy==1.20.1
 omnijson==0.1.2                        # via katportalclient
 packaging==21.3                        # via sphinx, bokeh, pytest
 pandas==1.2.2
-pillow==9.0.1                          # via bokeh, matplotlib
+pillow==9.3.0                          # via bokeh, matplotlib
 pluggy==0.13.1                         # via pytest
 pygelf==0.4.0
 pygments==2.8.0                        # via sphinx
@@ -102,6 +102,6 @@ toolz==0.10.0                          # via dask
 tornado==6.1
 typing==3.7.4.3
 typing_extensions==4.4.0
-ujson==4.0.2                           # via katportalclient
+ujson==5.4.0                           # via katportalclient
 urllib3==1.26.5                        # via requests
 yarl==1.6.3                            # via aiohttp

--- a/docker-base-build/pre-requirements.txt
+++ b/docker-base-build/pre-requirements.txt
@@ -4,7 +4,7 @@ pep517==0.12.0          # via pip-tools
 pip==21.3.1
 pip-tools==6.4.0        # via install_pinned.py
 pyparsing==3.0.6        # via packaging
-setuptools==59.4.0
+setuptools==65.5.1
 six==1.16.0             # via install-requirements.py (remove in future)
 tomli==1.2.2            # via pep517
 wheel==0.37.0


### PR DESCRIPTION
This should subsume some of the PRs that Dependabot opened. I left alone pyjwt, numpy and dask, since they're high-risk updates and I don't want them to be my problem.

markupsafe wasn't directly flagged by dependabot, but it flagged a dependent in a downstream repo that needs a newer markupsafe to be upgraded.