### PR TITLE
Roll back an update to markupsafe

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -47,7 +47,7 @@ kiwisolver==1.3.1                      # via matplotlib
 llvmlite==0.34.0                       # via numba
 mako==1.2.2
 manhole==1.6.0                         # TODO: only used by katsdpdisp - could remove
-markupsafe==2.1.2                      # via jinja2, mako
+markupsafe==1.1.1                      # via jinja2, mako
 matplotlib==3.3.4
 msgpack==1.0.2
 multidict==5.1.0                       # via yarl, aiohttp


### PR DESCRIPTION
It needs an updated jinja2 to work, and that in turn requires an update to aiohttp_jinja2. It's turning into more interactions with SDP packages than I want to be responsible for.