### PR TITLE
SPR1-2766: Support katsdptelstate 0.13

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -3,7 +3,6 @@ aiohttp==3.8.1
 aiohttp-retry==2.3.3
 aiokatcp==1.6.1
 aiomonitor==0.4.5
-aioredis==2.0.0
 aiosignal==1.2.0                       # via aiohttp
 alabaster==0.7.12                      # via sphinx
 ansicolors==1.1.8
@@ -30,11 +29,11 @@ decorator==4.4.2
 defusedxml==0.6.0
 docutils==0.16
 ephem==3.7.7.1
-fakeredis==1.6.1
+fakeredis==2.10.0
 frozenlist==1.3.0                      # via aiohttp, aiosignal
 future==0.18.2
 h5py==3.1.0
-hiredis==1.1.0
+hiredis==2.2.2
 idna==2.10                             # via requests, yarl
 imagesize==1.2.0                       # via sphinx
 iniconfig==1.1.1                       # via pytest
@@ -78,12 +77,12 @@ python-lzf==0.2.4
 pytz==2021.1                           # via pandas, Babel
 pyyaml==5.4.1
 rdbtools==0.1.15
-redis==3.5.3
+redis==4.5.1
 requests==2.25.1
 scipy==1.6.1
 six==1.16.0
 snowballstemmer==2.1.0                 # via sphinx
-sortedcontainers==2.3.0                # via fakeredis
+sortedcontainers==2.4.0                # via fakeredis
 spead2==3.2.1
 sphinxcontrib-applehelp==1.0.2         # via sphinx
 sphinxcontrib-devhelp==1.0.2           # via shpinx


### PR DESCRIPTION
This bumps redis-py and friends to the latest versions. These should all be accessed via katsdptelstate, which makes it safe to upgrade.

Katsdptelstate 0.13 now depends on redis-py >= 4.2, which has aioredis built in and therefore does not require the standalone aioredis package anymore. I've updated hiredis as well, as the redis-py 4.5.0 changelog suggests hiredis >= 2.2.1 for improved write access.