### PR TITLE
SPR1-2766: Add lupa==1.14.1 to docker base

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -44,6 +44,7 @@ katportalclient==0.2.2
 katversion==1.1
 kiwisolver==1.3.1                      # via matplotlib
 llvmlite==0.34.0                       # via numba
+lupa==1.14.1                           # via fakeredis[lua]
 mako==1.2.2
 manhole==1.6.0                         # TODO: only used by katsdpdisp - could remove
 markupsafe==1.1.1                      # via jinja2, mako


### PR DESCRIPTION
This is still some minor fallout of the katsdptelstate 0.13 release.

As discussed in ska-sa/katsdpimager#124, it is useful to pull lupa into docker base as it is a dependency of `fakeredis[lua]`, and the two packages typically go hand-in-hand in our packages.

Currently the two are used in the tests of `katsdptelstate` and `katsdpimager`. This change avoids updating lupa in *two* places in future (the minimum to make this beneficial :-) ).