### PR TITLE
SPR1-3065: Upgrade long-overdue base dependencies

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -1,9 +1,3 @@
-jsonschema-specifications==2023.03.6
-rpds-py==0.7.1
-referencing==0.28.4
-pkgutil-resolve-name==1.3.10
-
-
 aioconsole==0.7.0                      # via aiomonitor
 aiohttp==3.9.3
 aiohttp-retry==2.8.3
@@ -51,10 +45,11 @@ jinja2==3.1.3
 janus==1.0
 jmespath==0.10.0                       # via botocore
 jsonschema==4.21.1
+jsonschema-specifications==2023.03.6
 katportalclient==0.2.2
 katversion==1.1
 kiwisolver==1.3.1                      # via matplotlib
-llvmlite==0.41.1                       # via numba
+llvmlite==0.34.0                       # via numba
 lupa==1.14.1                           # via fakeredis[lua]
 mako==1.2.2
 manhole==1.6.0                         # TODO: only used by katsdpdisp - could remove
@@ -66,12 +61,13 @@ mypy==0.991
 mypy-extensions==0.4.3                 # via mypy
 netifaces==0.11.0
 nose==1.3.7
-numba==0.58.1                          # Not the latest due to https://github.com/numba/numba/issues/6819
-numpy==1.24.4                                                                                            
+numba==0.51.2                          # Not the latest due to https://github.com/numba/numba/issues/6819
+numpy==1.20.1                                                                                            
 omnijson==0.1.2                        # via katportalclient
 packaging==23.2                        # via sphinx, bokeh, pytest
 pandas==1.2.2
 pillow==9.3.0                          # via bokeh, matplotlib
+pkgutil-resolve-name==1.3.10
 pluggy==0.13.1                         # via pytest
 prompt-toolkit==3.0
 pygelf==0.4.2
@@ -94,7 +90,9 @@ pytz==2021.1                           # via pandas, Babel
 pyyaml==6.0.1
 rdbtools==0.1.15
 redis==4.6.0
+referencing==0.28.4
 requests==2.31.0
+rpds-py==0.7.1
 scipy==1.10.1
 six==1.16.0
 snowballstemmer==2.1.0                 # via sphinx

--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -1,93 +1,107 @@
-aioconsole==0.3.1                      # via aiomonitor
-aiohttp==3.8.1
-aiohttp-retry==2.3.3
-aiokatcp==1.7.0
-aiomonitor==0.4.5
-aiosignal==1.2.0                       # via aiohttp
+jsonschema-specifications==2023.03.6
+rpds-py==0.7.1
+referencing==0.28.4
+pkgutil-resolve-name==1.3.10
+
+
+aioconsole==0.7.0                      # via aiomonitor
+aiohttp==3.9.3
+aiohttp-retry==2.8.3
+aiokatcp==1.8.0
+aiomonitor==0.7.0
+aiosignal==1.3.1                       # via aiohttp
 alabaster==0.7.12                      # via sphinx
 ansicolors==1.1.8
 appdirs==1.4.4
 argparse==1.4.0                        # via python-casacore
-astropy==4.2
-async-timeout==4.0.2
+astropy==4.2    # 5.2.2
+async-timeout==4.0.3
 asynctest==0.13.0
-attrs==20.3.0
+attrs==22.2.0
 Babel==2.9.1                           # via sphinx
-bokeh==2.3.0
+backports-strenum==1.2.4
+bokeh==2.3.0                                                                                       
 botocore==1.19.52                      # Not the latest due to aiobotocore restriction
-certifi==2022.12.7                     # via requests
-chardet==3.0.4                         # via requests, aiohttp (not 4.x due to aiohttp restriction)
+certifi==2024.2.2                      # via requests
+chardet==3.0.4                         # via requests, aiohttp (not 4.x due to aiohttp restriction)        
 charset-normalizer==2.0.12             # via aiohttp
 cityhash==0.2.3.post9
+click==8.0
 coverage==5.5
 cycler==0.10.0                         # via matplotlib
 # Not the latest dask due to several bugs:
 # https://github.com/dask/dask/issues/7402
 # https://github.com/dask/dask/issues/7632
-dask==2.27
-decorator==4.4.2
+dask==2.27  # dask==2023.5.0 
+decorator==5.1.1
 defusedxml==0.6.0
 docutils==0.16
-ephem==3.7.7.1
+ephem==4.1.5
 fakeredis==2.10.0
-frozenlist==1.3.0                      # via aiohttp, aiosignal
-future==0.18.2
-h5py==3.1.0
-hiredis==2.2.2
-idna==2.10                             # via requests, yarl
+frozenlist==1.4.1                      # via aiohttp, aiosignal
+future==0.18.3
+h5py==3.10.0
+hiredis==2.3.2
+idna==3.6                              # via requests, yarl
 imagesize==1.2.0                       # via sphinx
-importlib-resources==5.12.0
+importlib-metadata==1.4
+importlib-resources==6.1.1
 iniconfig==1.1.1                       # via pytest
-jinja2==2.11.3
+jinja2==3.1.3
+janus==1.0
 jmespath==0.10.0                       # via botocore
-jsonschema==3.2.0
+jsonschema==4.21.1
 katportalclient==0.2.2
 katversion==1.1
 kiwisolver==1.3.1                      # via matplotlib
-llvmlite==0.34.0                       # via numba
+llvmlite==0.41.1                       # via numba
 lupa==1.14.1                           # via fakeredis[lua]
 mako==1.2.2
 manhole==1.6.0                         # TODO: only used by katsdpdisp - could remove
-markupsafe==1.1.1                      # via jinja2, mako
+markupsafe==2.1.5                      # via jinja2, mako
 matplotlib==3.3.4
 msgpack==1.0.2
-multidict==5.1.0                       # via yarl, aiohttp
+multidict==6.0.5                       # via yarl, aiohttp
 mypy==0.991
 mypy-extensions==0.4.3                 # via mypy
-netifaces==0.10.9
+netifaces==0.11.0
 nose==1.3.7
-numba==0.51.2                          # Not the latest due to https://github.com/numba/numba/issues/6819
-numpy==1.20.1
+numba==0.58.1                          # Not the latest due to https://github.com/numba/numba/issues/6819
+numpy==1.24.4                                                                                            
 omnijson==0.1.2                        # via katportalclient
-packaging==21.3                        # via sphinx, bokeh, pytest
+packaging==23.2                        # via sphinx, bokeh, pytest
 pandas==1.2.2
 pillow==9.3.0                          # via bokeh, matplotlib
 pluggy==0.13.1                         # via pytest
-pygelf==0.4.0
+prompt-toolkit==3.0
+pygelf==0.4.2
 pygments==2.8.0                        # via sphinx
 py==1.10.0                             # via pytest
+#pycuda==2020.1
 pyephem==9.99                          # backwards compatibility for katpoint 0.9
-pyerfa==1.7.2                          # via astropy
+pyerfa==2.0.0                          # via astropy
 pyjwt==2.4.0
-pyparsing==3.0.6                       # via packaging, matplotlib
+#pyopencl==2020.1 
+pyparsing==3.0.6                       # via packaging, 
 pyrsistent==0.17.3                     # via jsonschema
 pytest==6.2.2
 pytest-cov==2.11.1
 python-casacore==3.3.1
 python-dateutil==2.8.1
 python-lzf==0.2.4
+pytools==2021.1
 pytz==2021.1                           # via pandas, Babel
-pyyaml==5.4.1
+pyyaml==6.0.1
 rdbtools==0.1.15
-redis==4.5.1
-requests==2.25.1
-scipy==1.6.1
+redis==4.6.0
+requests==2.31.0
+scipy==1.10.1
 six==1.16.0
 snowballstemmer==2.1.0                 # via sphinx
 sortedcontainers==2.4.0                # via fakeredis
 spead2==3.2.1
 sphinxcontrib-applehelp==1.0.2         # via sphinx
-sphinxcontrib-devhelp==1.0.2           # via shpinx
+sphinxcontrib-devhelp==1.0.2           # via sphinx
 sphinxcontrib-htmlhelp==1.0.3          # via sphinx
 sphinxcontrib-jsmath==1.0.1            # via sphinx
 sphinxcontrib-qthelp==1.0.3            # via sphinx
@@ -96,14 +110,16 @@ sphinxcontrib-websupport==1.2.4        # via sphinx
 sphinx-rtd-theme==0.5.1
 sphinx==3.5.1
 strict-rfc3339==0.7
-terminaltables==3.1.0                  # via aiomonitor
+terminaltables==3.1.10                 # via aiomonitor
 toml==0.10.2                           # via pytest
 tomli==1.2.2                           # via mypy
-toolz==0.10.0                          # via dask
-tornado==6.1
+toolz==0.12.1                          # via dask
+tornado==6.4
+trafaret==2.1.1
 typing==3.7.4.3
-typing_extensions==4.4.0
-ujson==5.4.0                           # via katportalclient
-urllib3==1.26.5                        # via requests
-yarl==1.6.3                            # via aiohttp
+typing-extensions==4.9.0
+ujson==5.9.0                           # via katportalclient
+urllib3==1.26.18                       # via requests
+wcwidth==0.1.5
+yarl==1.9.4                            # via aiohttp
 zipp==3.15.0                           # via importlib-resources


### PR DESCRIPTION
As discussed in various other places, this PR will enact a long-overdue upgrade to a range of requirements in docker-base-build. Numpy and numba remain held back for now due to https://github.com/numba/numba/issues/6819, as well as dask (https://skaafrica.atlassian.net/browse/SPR1-1790).

I'm not above rolling this back if it breaks downstream builds.