### PR TITLE
SPR1-3127 update fakeredis to match newer redis

### DIFF
--- a/docker-base-build/base-requirements.txt
+++ b/docker-base-build/base-requirements.txt
@@ -31,7 +31,7 @@ decorator==5.1.1
 defusedxml==0.6.0
 docutils==0.20.1                       # via sphinx
 ephem==4.1.5
-fakeredis==2.10.0
+fakeredis==2.22.0
 frozenlist==1.4.1                      # via aiohttp, aiosignal
 future==0.18.3
 h5py==3.10.0


### PR DESCRIPTION
redis was recently updated from 4.5.1 to 4.6.0 in base-reqs. This PR (https://github.com/redis/redis-py/pull/2583), included within that update, added a disconnect_on_error parameter to read_response(), which is causing tests to fail in katsdptelstate. Update fakeredis to a newer version to resolve this. https://skaafrica.atlassian.net/browse/SPR1-3127