### PR TITLE
Use uv pip for base dependency installs

### DIFF
--- a/docker-base-build/Dockerfile
+++ b/docker-base-build/Dockerfile
@@ -38,7 +38,9 @@ COPY install_pinned.py /usr/local/bin
 RUN virtualenv -p /usr/bin/python3 ~/tmp-ve3 && \
     . ~/tmp-ve3/bin/activate && \
     pip install -r ~/docker-base/pre-requirements.txt && \
-    install_pinned.py -r ~/docker-base/base-requirements.txt && \
+    uv pip compile ~/docker-base/base-requirements.txt -o ~/docker-base/base-requirements.lock && \
+    uv pip install --no-deps -r ~/docker-base/base-requirements.lock && \
+    uv pip check && \
     rm -r ~/tmp-ve3
 
 # Create empty virtual environment for child images to install to

--- a/docker-base-build/pre-requirements.txt
+++ b/docker-base-build/pre-requirements.txt
@@ -7,4 +7,5 @@ pyparsing==3.0.6        # via packaging
 setuptools==65.5.1
 six==1.16.0             # via install-requirements.py (remove in future)
 tomli==1.2.2            # via pep517
+uv==0.8.4
 wheel==0.37.0

--- a/docker-base-gpu-build/Dockerfile
+++ b/docker-base-gpu-build/Dockerfile
@@ -47,12 +47,14 @@ COPY requirements.txt /home/kat/docker-base/gpu-requirements.txt
 RUN virtualenv -p /usr/bin/python3 ~/tmp-ve3 && \
     . ~/tmp-ve3/bin/activate && \
     pip install -r ~/docker-base/pre-requirements.txt && \
-    install_pinned.py -c ~/docker-base/base-requirements.txt numpy && \
-    install_pinned.py -c ~/docker-base/base-requirements.txt -r ~/docker-base/gpu-requirements.txt && \
+    uv pip compile -c ~/docker-base/base-requirements.txt ~/docker-base/gpu-requirements.txt -o ~/docker-base/gpu-requirements.lock && \
+    uv pip install --no-deps -c ~/docker-base/gpu-requirements.lock numpy && \
+    uv pip install --no-cache --no-deps --no-binary pycuda --no-build-isolation -c ~/docker-base/gpu-requirements.lock pycuda && \
+    uv pip install --no-deps -r ~/docker-base/gpu-requirements.lock && \
+    uv pip check && \
     rm -rf ~/tmp-ve3
 
 # For nvidia-container-runtime 
 # driver backwards compatability not guaranteed across minor versions when using PTX:
 # https://docs.nvidia.com/deploy/cuda-compatibility/index.html#application-considerations
 ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility NVIDIA_REQUIRE_CUDA=cuda>=11.4 
-


### PR DESCRIPTION
This migrates the shared build path from `install_pinned.py` to `uv pip`. Base images now preinstall a pinned uv and use `uv pip compile` followed by `uv pip install --no-deps` and `uv pip check` to build their Python environments. Jenkins package builds follow the same pattern: compile each requirements file against the checked-out katsdpdockerbase base/GPU constraints, install the generated lock, and run `uv pip check`. 

This keeps the migration focused on replacing the custom installer with standard uv tooling; cleanup of legacy package requirement files that still embed katsdpdockerbase -c/-d lines will be handled separately.